### PR TITLE
Threaded Binary Tree

### DIFF
--- a/P5.CPP
+++ b/P5.CPP
@@ -27,3 +27,36 @@ int main() {
     }
     return 0;
 }
+
+// Utility function to find leftmost node in a tree rooted
+// with n
+Node leftMost(Node n)
+{
+if (n == null)
+	return null;
+
+while (n.left != null)
+	n = n.left;
+
+return n;
+}
+
+// C code to do inorder traversal in a threaded binary tree
+static void inOrder(Node root)
+{
+Node cur = leftMost(root);
+while (cur != null)
+{
+	Console.Write("{0} ", cur.data);
+
+	// If this node is a thread node, then go to
+	// inorder successor
+	if (cur.rightThread)
+	cur = cur.right;
+	else // Else go to the leftmost child in right
+	// subtree
+	cur = leftmost(cur.right);
+}
+}
+
+// This code is contributed by gauravrajput1


### PR DESCRIPTION
Since right pointer is used for two purposes, the boolean variable rightThread is used to indicate whether right pointer points to right child or inorder successor. Similarly, we can add leftThread for a double threaded binary tree.